### PR TITLE
Fixing platform().loggedIn function

### DIFF
--- a/public/js/ctiscreenpop.js
+++ b/public/js/ctiscreenpop.js
@@ -117,7 +117,7 @@ function rcCallWinMgr(rcSdk) {
         console.log('createSubscription');
     }
     t.endSubscription = function() {
-        if (t.rcSdk.platform.loggedIn()) {
+        if (t.rcSdk.platform().loggedIn()) {
             if (t.subscription) {
                 t.subscription.remove({async: false});
             }


### PR DESCRIPTION
Changed to `rcSdk.platform().loggedIn()`

File: `public/js/ctiscreenpop.js`
